### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -1,9 +1,9 @@
-class Dataset():
+class Dataset:
     def __init__(self, relations):
         self.relations = relations
 
 
-class Relation():
+class Relation:
     def __init__(self, sent, first_pos, second_pos, label):
         self.sent = sent
         self.first_pos = first_pos

--- a/semevalparser.py
+++ b/semevalparser.py
@@ -1,7 +1,7 @@
 from dataset import Relation, Dataset
 
 
-class SemEvalParser():
+class SemEvalParser:
     def retrieve_from_sem_eval(self, path):
         with open(path) as infile:
             instring = infile.read()


### PR DESCRIPTION
It is best practice to leave away parentheses after `class Foo` if it does not inherit.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pkuhn/relationshipextractor/1)

<!-- Reviewable:end -->
